### PR TITLE
Potential fix for code scanning alert no. 5: Disabled Spring CSRF protection

### DIFF
--- a/src/main/java/org/openwms/core/process/execution/app/ProcessExecutionSecurityConfiguration.java
+++ b/src/main/java/org/openwms/core/process/execution/app/ProcessExecutionSecurityConfiguration.java
@@ -40,7 +40,7 @@ class ProcessExecutionSecurityConfiguration {
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
         http.authorizeHttpRequests(x -> x.anyRequest().permitAll())
-                .csrf(AbstractHttpConfigurer::disable)
+                .csrf().and()
                 .addFilter(new CorsFilter(new PermitAllCorsConfigurationSource()));
         return http.build();
     }


### PR DESCRIPTION
Potential fix for [https://github.com/Banyaon/org.openwms.core.process.execution/security/code-scanning/5](https://github.com/Banyaon/org.openwms.core.process.execution/security/code-scanning/5)

To fix the problem, we need to enable CSRF protection in the `ProcessExecutionSecurityConfiguration` class. This involves removing the line that disables CSRF protection and ensuring that CSRF protection is enabled by default. This change will help protect the application from CSRF attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
